### PR TITLE
Fix cannon loading

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ org.gradle.parallel=true
 	loader_version=0.15.3
 
 # Mod Properties
-	mod_version = 1.2.1
+	mod_version = 1.2.2
 	maven_group = dev.kikugie
 	archives_base_name = ucsm
 

--- a/src/main/kotlin/dev/kikugie/ucsm/UCSM.kt
+++ b/src/main/kotlin/dev/kikugie/ucsm/UCSM.kt
@@ -9,7 +9,7 @@ import org.slf4j.LoggerFactory
 import java.nio.file.Path
 
 object UCSM : ClientModInitializer {
-    val LOGGER = LoggerFactory.getLogger("ECSM")
+    val LOGGER = LoggerFactory.getLogger("UCSM")
     val CONFIG = FabricLoader.getInstance().configDir.resolve("ucsm")
     val cannonCache = mutableMapOf<Path, CannonInstance>()
     var cannon: CannonInstance? = null

--- a/src/main/kotlin/dev/kikugie/ucsm/cannon/CannonInstance.kt
+++ b/src/main/kotlin/dev/kikugie/ucsm/cannon/CannonInstance.kt
@@ -30,7 +30,7 @@ class CannonInstance(val file: Path, vals: Sequence<Pair<String, String>>) {
     }
 
     private fun addTree(pt: String, ct: String) {
-        val (x, y, z) = pt.split(',', limit = 2)
+        val (x, y, z) = pt.split(',', limit = 3)
         try {
             tree.addPoint(doubleArrayOf(x.toDouble(), y.toDouble(), z.toDouble()), ct)
         } catch (ignored: Exception) {
@@ -44,7 +44,7 @@ class CannonInstance(val file: Path, vals: Sequence<Pair<String, String>>) {
     }
 
     companion object {
-        val coords = Regex("\\d+,\\d+,\\d+")
+        val coords = Regex("(-?\\d+\\.\\d+),(-?\\d+\\.\\d+),(-?\\d+\\.\\d+)")
         val LOAD_ERROR = DynamicCommandExceptionType { file -> Text.of("File not found: $file") }
 
         fun loadDir(dir: Path): CannonInstance {

--- a/src/main/kotlin/dev/kikugie/ucsm/cannon/CannonInstance.kt
+++ b/src/main/kotlin/dev/kikugie/ucsm/cannon/CannonInstance.kt
@@ -23,28 +23,28 @@ class CannonInstance(val file: Path, vals: Sequence<Pair<String, String>>) {
 
     init {
         vals.forEach { (pt, ct) ->
-            if (coords.matchEntire(pt) != null)
-                addTree(pt, ct)
-            else extras[pt] = ct
+            if (addTree(pt, ct)) extras[pt] = ct
         }
     }
 
-    private fun addTree(pt: String, ct: String) {
-        val (x, y, z) = pt.split(',', limit = 3)
-        try {
+    private fun addTree(pt: String, ct: String): Boolean {
+        return try {
+            val (x, y, z) = pt.split(',')
+                .takeIf { it.size == 3 } ?: return false
             tree.addPoint(doubleArrayOf(x.toDouble(), y.toDouble(), z.toDouble()), ct)
+            false
         } catch (ignored: Exception) {
+            true
         }
     }
 
-    fun setProperites(pos: BlockPos, facing: Direction, mirror: Boolean) {
+    fun setProperties(pos: BlockPos, facing: Direction, mirror: Boolean) {
         origin = pos
         direction = facing
         mirrored = mirror
     }
 
     companion object {
-        val coords = Regex("(-?\\d+\\.\\d+),(-?\\d+\\.\\d+),(-?\\d+\\.\\d+)")
         val LOAD_ERROR = DynamicCommandExceptionType { file -> Text.of("File not found: $file") }
 
         fun loadDir(dir: Path): CannonInstance {

--- a/src/main/kotlin/dev/kikugie/ucsm/cannon/CannonInstance.kt
+++ b/src/main/kotlin/dev/kikugie/ucsm/cannon/CannonInstance.kt
@@ -1,36 +1,98 @@
 package dev.kikugie.ucsm.cannon
 
-import com.mojang.brigadier.exceptions.DynamicCommandExceptionType
 import dev.kikugie.ucsm.UCSM
 import it.unimi.dsi.fastutil.objects.Object2ObjectAVLTreeMap
 import jk.tree.KDTree
+import jk.tree.KDTree.SearchResult
+import kotlinx.coroutines.*
 import net.minecraft.client.MinecraftClient
 import net.minecraft.text.Text
 import net.minecraft.util.math.BlockPos
 import net.minecraft.util.math.Direction
+import net.minecraft.util.math.Vec3d
 import net.minecraft.util.math.Vec3i
 import java.nio.file.Path
-import kotlin.io.path.notExists
-import kotlin.io.path.readLines
+import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.io.path.name
+import kotlin.io.path.useLines
 
-class CannonInstance(val file: Path, vals: Sequence<Pair<String, String>>) {
-    val tree = KDTree<String>()
-    val extras = Object2ObjectAVLTreeMap<String, String>()
+class CannonInstance(val file: Path) {
+    private lateinit var tree: KDTree<String>
+    private lateinit var extras: Object2ObjectAVLTreeMap<String, String>
+    private var locked = AtomicBoolean(false)
+    private val _loaded = AtomicBoolean(false)
+    private var process: Deferred<Unit>? = null
+    val loaded: Boolean
+        get() = _loaded.get()
 
     var origin: Vec3i? = null
     var direction: Direction? = null
     var mirrored: Boolean? = null
 
+    val configs = file.resolve("Ct.txt")
+    val points = file.resolve("Pt.txt")
+
     init {
-        vals.forEach { (pt, ct) ->
-            if (addTree(pt, ct)) extras[pt] = ct
+        reload()
+    }
+
+    fun getExtrasSafe(): Map<String, String>? = if (loaded) {
+        extras
+    } else null
+
+
+    fun getCoord(pos: Vec3d): SearchResult<String>? = if (loaded) {
+        tree.nearestNeighbour(pos)
+    } else {
+        sendError("This cannon is not loaded yet")
+        null
+    }
+
+
+    fun getExtra(str: String): String? = if (loaded) {
+        extras[str]
+    } else {
+        sendError("This cannon is not loaded yet")
+        null
+    }
+
+    fun unload() {
+        process?.cancel()
+    }
+
+    @OptIn(DelicateCoroutinesApi::class)
+    fun reload() {
+        if (locked.get()) {
+            sendError("This cannon is already loading")
+            return
+        }
+
+        locked.set(true)
+        _loaded.set(false)
+        tree = KDTree<String>()
+        extras = Object2ObjectAVLTreeMap<String, String>()
+        process = GlobalScope.async {
+            try {
+                points.useLines { pts ->
+                    configs.useLines { cts ->
+                        pts.zip(cts).forEach { (pt, ct) ->
+                            if (addTree(pt, ct)) extras[pt] = ct
+                        }
+                    }
+                }
+                _loaded.set(true)
+                sendMessage("Cannon \"${file.name}\" is loaded")
+            } catch (e: Exception) {
+                sendError(e.message ?: "Failed to load cannon instance: $file")
+            }
+            locked.set(false)
         }
     }
 
     private fun addTree(pt: String, ct: String): Boolean {
         return try {
             val (x, y, z) = pt.split(',')
-                .takeIf { it.size == 3 } ?: return false
+                .takeIf { it.size == 3 } ?: return true
             tree.addPoint(doubleArrayOf(x.toDouble(), y.toDouble(), z.toDouble()), ct)
             false
         } catch (ignored: Exception) {
@@ -44,24 +106,17 @@ class CannonInstance(val file: Path, vals: Sequence<Pair<String, String>>) {
         mirrored = mirror
     }
 
+    private fun sendError(message: String) {
+        MinecraftClient.getInstance().player?.sendMessage(Text.of("§4$message")) ?: UCSM.LOGGER.error(message)
+    }
+
+    private fun sendMessage(message: String) {
+        MinecraftClient.getInstance().player?.sendMessage(Text.of("§a$message")) ?: UCSM.LOGGER.info(message)
+    }
+
     companion object {
-        val LOAD_ERROR = DynamicCommandExceptionType { file -> Text.of("File not found: $file") }
-
-        fun loadDir(dir: Path): CannonInstance {
-            val root = MinecraftClient.getInstance().runDirectory.toPath()
-            val ct = dir.resolve("Ct.txt").also {
-                if (it.notExists()) throw LOAD_ERROR.create(root.relativize(it))
-            }
-            val pt = dir.resolve("Pt.txt").also {
-                if (it.notExists()) throw LOAD_ERROR.create(root.relativize(it))
-            }
-            return CannonInstance(dir, pt.readLines().asSequence().zip(ct.readLines().asSequence())).also {
-                UCSM.cannonCache[dir] = it
-            }
-        }
-
         fun lazyLoad(dir: Path): CannonInstance {
-            return UCSM.cannonCache[dir] ?: loadDir(dir)
+            return UCSM.cannonCache.computeIfAbsent(dir) { CannonInstance(it) }
         }
     }
 }

--- a/src/main/kotlin/dev/kikugie/ucsm/command/CannonConfigArgumentType.kt
+++ b/src/main/kotlin/dev/kikugie/ucsm/command/CannonConfigArgumentType.kt
@@ -14,7 +14,7 @@ import java.util.concurrent.CompletableFuture
 class CannonConfigArgumentType : ArgumentType<String> {
     val INVALID_CONFIG = SimpleCommandExceptionType(Text.of("Invalid cannon config"))
     val configs: Collection<String>?
-        get() = UCSM.cannon?.extras?.keys
+        get() = UCSM.cannon?.getExtrasSafe()?.keys
 
     override fun parse(reader: StringReader): String {
         val remainder = reader.readUnquotedString()

--- a/src/main/kotlin/dev/kikugie/ucsm/command/ModCommand.kt
+++ b/src/main/kotlin/dev/kikugie/ucsm/command/ModCommand.kt
@@ -156,7 +156,7 @@ object ModCommand {
         mirrored: Boolean
     ): Int {
         checkInstance()
-        UCSM.cannon!!.setProperites(pos, facing, mirrored)
+        UCSM.cannon!!.setProperties(pos, facing, mirrored)
         context.source.sendFeedback(Text.of("§oOrigin set to ${pos.toShortString()} facing ${facing.asString()}"))
         return 0;
     }

--- a/src/main/kotlin/dev/kikugie/ucsm/command/ModCommand.kt
+++ b/src/main/kotlin/dev/kikugie/ucsm/command/ModCommand.kt
@@ -34,6 +34,7 @@ object ModCommand {
                 .executes(::help)
                 .then(literal("help").executes(::help))
                 .then(literal("reload").executes(::reload))
+                .then(literal("unload").executes(::unload))
                 .then(
                     literal("load").then(
                         argument("dir", DirectoryArgumentType(UCSM.CONFIG))
@@ -80,16 +81,32 @@ object ModCommand {
         )
     }
 
+    private fun unload(context: CommandContext<FabricClientCommandSource>): Int {
+        checkInstance()
+        UCSM.cannon!!.also {
+            it.unload()
+            UCSM.cannonCache.remove(it.file)
+            context.source.sendFeedback(Text.of("§aUnloaded cannon ${it.file.name}"))
+        }
+        return 0
+    }
+
     private fun configTarget(context: CommandContext<FabricClientCommandSource>): Int {
         checkInstance()
         val config = context.getArgument("config", String::class.java)
-        context.source.sendFeedback(Text.of("§aConfiguration: ${UCSM.cannon!!.extras[config]}"))
+        val result = UCSM.cannon?.getExtra(config) ?: return -1
+        context.source.sendFeedback(Text.of("§aConfiguration: $result"))
         return 0
     }
 
     private fun posTarget(context: CommandContext<FabricClientCommandSource>): Int =
-        context.source.let { setTarget(getPosFromArgument(
-            context.getArgument("pos", DefaultPosArgument::class.java), it), it) }
+        context.source.let {
+            setTarget(
+                getPosFromArgument(
+                    context.getArgument("pos", DefaultPosArgument::class.java), it
+                ), it
+            )
+        }
 
     private fun raycastTarget(context: CommandContext<FabricClientCommandSource>): Int {
         val source = context.source
@@ -126,7 +143,7 @@ object ModCommand {
             target = Vec3d(-target.x, target.y, target.z)
         }
 
-        val result = cannon.tree.nearestNeighbour(target)
+        val result = cannon.getCoord(target) ?: return -1
         return if (result.distance > precision) {
             source.sendError(Text.of("Your target is too far away!"))
             -1
@@ -137,7 +154,8 @@ object ModCommand {
     }
 
     private fun originFromPos(context: CommandContext<FabricClientCommandSource>, mirrored: Boolean): Int =
-        setOrigin(context,
+        setOrigin(
+            context,
             getPosFromArgument(
                 context.getArgument("pos", DefaultPosArgument::class.java),
                 context.source
@@ -158,7 +176,7 @@ object ModCommand {
         checkInstance()
         UCSM.cannon!!.setProperties(pos, facing, mirrored)
         context.source.sendFeedback(Text.of("§oOrigin set to ${pos.toShortString()} facing ${facing.asString()}"))
-        return 0;
+        return 0
     }
 
     private fun tntRange(context: CommandContext<FabricClientCommandSource>): Int {
@@ -170,36 +188,41 @@ object ModCommand {
     private fun load(context: CommandContext<FabricClientCommandSource>): Int {
         val dir = context.getArgument("dir", Path::class.java)
         UCSM.cannon = CannonInstance.lazyLoad(dir)
-        context.source.sendFeedback(Text.of("§oLoaded cannon ${dir.name}"))
+        context.source.sendFeedback(Text.of("§oLoading cannon ${dir.name}"))
         return 0
     }
 
     private fun reload(context: CommandContext<FabricClientCommandSource>): Int {
         checkInstance()
         val dir = UCSM.cannon!!.file
-        UCSM.cannon = CannonInstance.loadDir(dir)
-        context.source.sendFeedback(Text.of("§oReloaded cannon ${dir.name}"))
+        UCSM.cannon!!.reload()
+        context.source.sendFeedback(Text.of("§oReloading cannon ${dir.name}"))
         return 0
     }
 
     private fun help(context: CommandContext<FabricClientCommandSource>): Int {
-        context.source.sendFeedback(Text.of("""
+        context.source.sendFeedback(
+            Text.of(
+                """
             §oCommand functionality:
             - load <dir>: Load cannon config from .minecraft/config/ucsm/{dir}. Cannon origins are preserved when switching.
-            - reload: Reload files for the current cannon. Origin is reset.
+            - reload: Reload files for the current cannon.
+            - unload: Unloads the current cannon entirely.
             - precision: Set the maximum valid distance from tnt to the target
             - origin [<pos> <direction>] [mirrored]: Set cannon origin to a location. If empty, uses player position and rotation.
             - target <conf>: If the active cannon has custom presets, finds the matching one. Doesn't require an origin to be set up.
             - target [<pos>]: Find the closest configuration to the given position. If empty, finds the block the player is looking at.
-        """.trimIndent()))
+        """.trimIndent()
+            )
+        )
         return 0
     }
 
-    fun checkInstance() {
+    private fun checkInstance() {
         if (UCSM.cannon == null) throw NO_INSTANCE.create()
     }
 
-    fun checkCannon() {
+    private fun checkCannon() {
         if (UCSM.cannon!!.origin == null) throw NO_ORIGIN.create()
     }
 


### PR DESCRIPTION
There was an issue with the loading of the cannon:
The regex matching coordinates was only matching positive integers (like "1,2,3").
Now it's matching signed floats (like "-44.844574,-4.932205,-165.382137").
There was also a typo on the split limit and the logger name.

It's now loading fine and adding all the coordinates to the cannon tree.
Please give me feedback!